### PR TITLE
Remove Pydantic v1 deep_update import

### DIFF
--- a/driconfig/__init__.py
+++ b/driconfig/__init__.py
@@ -16,7 +16,6 @@ from typing import Any, ClassVar
 import yaml
 from pydantic import BaseModel, ConfigDict
 from pydantic.fields import FieldInfo
-from pydantic.v1.utils import deep_update
 from pydantic_settings import BaseSettings
 from pydantic_settings.sources import (
     EnvSettingsSource,
@@ -26,6 +25,25 @@ from pydantic_settings.sources import (
 from yaml import YAMLError
 
 __version__ = version(__name__)
+
+
+def _deep_update(
+    mapping: Mapping[str, Any],
+    *updating_mappings: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Merge mappings recursively without importing Pydantic v1 utilities."""
+    updated_mapping = dict(mapping)
+    for updating_mapping in updating_mappings:
+        for key, value in updating_mapping.items():
+            if (
+                key in updated_mapping
+                and isinstance(updated_mapping[key], dict)
+                and isinstance(value, dict)
+            ):
+                updated_mapping[key] = _deep_update(updated_mapping[key], value)
+            else:
+                updated_mapping[key] = value
+    return updated_mapping
 
 
 class DriConfigConfigDict(ConfigDict, total=False):
@@ -180,7 +198,7 @@ class DriConfig(BaseModel):
             yaml_config=yaml_config,
         )
         if sources:
-            return deep_update(*reversed([source() for source in sources]))
+            return _deep_update(*reversed([source() for source in sources]))
         return {}
 
     model_config: ClassVar[DriConfigConfigDict] = DriConfigConfigDict(
@@ -275,7 +293,7 @@ class YamlConfigSource(EnvSettingsSource):
     ) -> Any:
         """Prepare the field value."""
         if isinstance(value, dict):
-            deep_update(value, self.explode_env_vars(field_name, field, self.env_vars))
+            _deep_update(value, self.explode_env_vars(field_name, field, self.env_vars))
         return value
 
     def __repr__(self) -> str:

--- a/tests/test_driconfig.py
+++ b/tests/test_driconfig.py
@@ -82,6 +82,41 @@ def test_driconfig_prefix(config_path: Path) -> None:
     assert app_config.parent_config["CHILD_CONFIG_A"] == 1
 
 
+def test_driconfig_deep_updates_sources(tmp_path: Path) -> None:
+    """Test nested configuration values from multiple sources."""
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(
+        "parent_config:\n"
+        "  child_config_a: yaml-a\n"
+        "  child_config_b: yaml-b\n",
+        encoding="utf-8",
+    )
+
+    class AppConfig(DriConfig):
+        """Test configuration."""
+
+        model_config = DriConfigConfigDict(
+            config_folder=tmp_path,
+            config_file_name=config_file.name,
+            case_sensitive=False,
+        )
+
+        parent_config: dict[str, str]
+
+    app_config = AppConfig(
+        parent_config={
+            "child_config_b": "init-b",
+            "child_config_c": "init-c",
+        }
+    )
+
+    assert app_config.parent_config == {
+        "child_config_a": "yaml-a",
+        "child_config_b": "init-b",
+        "child_config_c": "init-c",
+    }
+
+
 def test_driconfig_fail() -> None:
     """Test DriConfig."""
 


### PR DESCRIPTION
## Summary
- replace the `pydantic.v1.utils.deep_update` import with a local recursive helper
- keep nested source merging covered with a focused regression test

Fixes #375.

## Validation
- `git diff --check`
- `git diff --cached --check`
- `git diff --check HEAD~1..HEAD`
- `rg -n pydantic\.v1 driconfig tests` (no matches)
- Not run locally: project test suite, lint, build, or install